### PR TITLE
Create Payment Request - add address and date of birth to user object

### DIFF
--- a/classes/class-truelayer-checkout.php
+++ b/classes/class-truelayer-checkout.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Main checkout file.
+ *
+ * @package TrueLayer_For_WooCommerce/Classes/Checkout
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Truelayer_Checkout class.
+ */
+class Truelayer_Checkout {
+    /**
+     * Truelayer_Checkout constructor.
+     */
+    public function __construct() {
+        add_filter('woocommerce_get_country_locale', array( $this, 'make_state_required' ), 10, 1);
+    }
+
+    /**
+     *
+     * Filter out default WooCommerce settings for country locale.
+     * If state is defined and hidden it should stay optional, otherwise it should be required.
+     *
+     * @return array
+     */
+    public function make_state_required( $country_locale ) {
+
+        //Hidden is not set if it's not true
+        foreach( $country_locale AS $country => $settings ) {
+            if( ! isset( $settings['state']['hidden'] ) || ( isset( $settings['state']['hidden'] ) && ! empty( $state_hidden = $settings['state']['hidden'] ) && ( false === $state_hidden ) ) ) {
+                $country_locale[$country]['state']['required'] = true;
+            }
+        }
+
+        return $country_locale;
+    }
+}
+new Truelayer_Checkout();

--- a/classes/requests/helpers/class-truelayer-helper-order.php
+++ b/classes/requests/helpers/class-truelayer-helper-order.php
@@ -43,4 +43,17 @@ class TrueLayer_Helper_Order {
 
 		return $account_holder_name;
 	}
+
+    /**
+     * Get order meta - user date of birth
+     * @param $order
+     * @return mixed
+     */
+    public static function get_user_date_of_birth( $order ) {
+
+        $birth_date = apply_filters('truelayer_birth_date_field', $order->get_meta( '_truelayer_user_birth_date', true ), $order->get_id(), $order);
+
+        return $birth_date;
+
+    }
 }

--- a/classes/requests/helpers/class-truelayer-helper-order.php
+++ b/classes/requests/helpers/class-truelayer-helper-order.php
@@ -51,7 +51,7 @@ class TrueLayer_Helper_Order {
      */
     public static function get_user_date_of_birth( $order ) {
 
-        $birth_date = apply_filters('truelayer_birth_date_field', $order->get_meta( '_truelayer_user_birth_date', true ), $order->get_id(), $order);
+        $birth_date =  $order->get_meta( apply_filters( 'truelayer_birth_date_field', '_truelayer_user_birth_date', $order->get_id(), $order ), true );
 
         return $birth_date;
 

--- a/classes/requests/post/class-truelayer-request-create-payment.php
+++ b/classes/requests/post/class-truelayer-request-create-payment.php
@@ -63,23 +63,26 @@ class TrueLayer_Request_Create_Payment extends TrueLayer_Request_Post {
             'user'            => array(
                 'name'  => TrueLayer_Helper_Order::get_account_holder_name( $order ),
                 'email' => $order->get_billing_email(),
-                'address' => array(
-                    'address_line1' => $order->get_billing_address_1(),
-                    'address_line2' => $order->get_billing_address_2(),
-                    'city' => $order->get_billing_city(),
-                    'state' => $order->get_billing_state(),
-                    'zip' => $order->get_billing_postcode(),
-                    'country_code' => $order->get_billing_country(),
-                ),
             ),
         );
+
+        if( ! empty( $order->get_billing_address_1() ) ) {
+            $body['user']['address'] = array(
+                'address_line1' => $order->get_billing_address_1(),
+                'address_line2' => $order->get_billing_address_2(),
+                'city' => $order->get_billing_city(),
+                'state' => ! empty( $state = $order->get_billing_state() ) ? $state : 'NA',
+                'zip' => $order->get_billing_postcode(),
+                'country_code' => $order->get_billing_country(),
+            );
+        }
 
         if( ! empty( $birth_date = TrueLayer_Helper_Order::get_user_date_of_birth( $order ) ) ) {
             $body['user']['date_of_birth'] = $birth_date;
         }
 
 		$customer_segment = $this->get_banking_providers();
-		if ( ! empty( $customer_segment ) ) {
+        if ( ! empty( $customer_segment ) ) {
 			$body['payment_method']['provider_selection']['filter']['customer_segments'] = $customer_segment;
 		}
 

--- a/classes/requests/post/class-truelayer-request-create-payment.php
+++ b/classes/requests/post/class-truelayer-request-create-payment.php
@@ -60,11 +60,23 @@ class TrueLayer_Request_Create_Payment extends TrueLayer_Request_Post {
 					),
 				),
 			),
-			'user'            => array(
-				'name'  => TrueLayer_Helper_Order::get_account_holder_name( $order ),
-				'email' => $order->get_billing_email(),
-			),
-		);
+            'user'            => array(
+                'name'  => TrueLayer_Helper_Order::get_account_holder_name( $order ),
+                'email' => $order->get_billing_email(),
+                'address' => array(
+                    'address_line1' => $order->get_billing_address_1(),
+                    'address_line2' => $order->get_billing_address_2(),
+                    'city' => $order->get_billing_city(),
+                    'state' => $order->get_billing_state(),
+                    'zip' => $order->get_billing_postcode(),
+                    'country_code' => $order->get_billing_country(),
+                ),
+            ),
+        );
+
+        if( ! empty( $birth_date = TrueLayer_Helper_Order::get_user_date_of_birth( $order ) ) ) {
+            $body['user']['date_of_birth'] = $birth_date;
+        }
 
 		$customer_segment = $this->get_banking_providers();
 		if ( ! empty( $customer_segment ) ) {

--- a/truelayer-for-woocommerce.php
+++ b/truelayer-for-woocommerce.php
@@ -214,6 +214,7 @@ if ( ! class_exists( 'TrueLayer_For_WooCommerce' ) ) {
 			include_once TRUELAYER_WC_PLUGIN_PATH . '/classes/class-truelayer-logger.php';
 			include_once TRUELAYER_WC_PLUGIN_PATH . '/classes/class-truelayer-status.php';
 			include_once TRUELAYER_WC_PLUGIN_PATH . '/classes/class-truelayer-assets.php';
+			include_once TRUELAYER_WC_PLUGIN_PATH . '/classes/class-truelayer-checkout.php';
 
 			include_once TRUELAYER_WC_PLUGIN_PATH . '/classes/admin/class-wc-truelayer-banners.php';
 			include_once TRUELAYER_WC_PLUGIN_PATH . '/classes/class-truelayer-encryption.php';


### PR DESCRIPTION
Address details and user date of birth are added to the user object on create payment request.
User date of birth saved as order meta '_truelayer_user_birth_date' - filter: truelayer_birth_date_field
Address data fetched from WC order billing fields.