### PR TITLE
Add and implement setting for release channel

### DIFF
--- a/classes/class-truelayer-fields.php
+++ b/classes/class-truelayer-fields.php
@@ -189,6 +189,14 @@ class TrueLayer_Fields {
 				'desc_tip' => true,
 			),
 
+			'truelayer_release_channel'                     => array(
+				'title'       => __( 'Release channel', 'truelayer-for-woocommerce' ),
+				'type'        => 'text',
+				'description' => __( 'Enter the release channel that you wish to use for TrueLayer', 'truelayer-for-woocommerce' ),
+				'default'     => '',
+				'desc_tip'    => true,
+			),
+
 			'truelayer_payment_page_type'               => array(
 				'title'    => __( 'Payments Page Types', 'truelayer-for-woocommerce' ),
 				'type'     => 'select',

--- a/classes/class-truelayer-gateway.php
+++ b/classes/class-truelayer-gateway.php
@@ -164,8 +164,8 @@ class TrueLayer_Payment_Gateway extends WC_Payment_Gateway {
 	 * @return array
 	 */
 	public function process_payment( $order_id ) {
-                $settings = get_option( 'woocommerce_truelayer_settings', array() );
-                $epp_enabled  = $settings['truelayer_payment_page_type'] ?? 'HPP';
+		$settings    = get_option( 'woocommerce_truelayer_settings', array() );
+		$epp_enabled = $settings['truelayer_payment_page_type'] ?? 'HPP';
 
 		$response = TrueLayer()->api->create_payment( $order_id );
 

--- a/classes/class-truelayer-gateway.php
+++ b/classes/class-truelayer-gateway.php
@@ -85,7 +85,6 @@ class TrueLayer_Payment_Gateway extends WC_Payment_Gateway {
 			$client_secret      = 'truelayer_client_secret';
 			$client_certificate = 'truelayer_client_certificate';
 		}
-		$settings             = get_option( 'woocommerce_truelayer_settings', array() );
 		$truelayer_options    = array( $private_key, $client_secret, $client_certificate );
 		$truelayer_encryption = Truelayer_Encryption::get_instance();
 		if ( ! empty( $settings[ $key ] ) ) {

--- a/classes/class-truelayer-gateway.php
+++ b/classes/class-truelayer-gateway.php
@@ -13,8 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class TrueLayer_Payment_Gateway.
  */
 class TrueLayer_Payment_Gateway extends WC_Payment_Gateway {
-
-
 	/**
 	 * Allowed currencies.
 	 *
@@ -28,6 +26,13 @@ class TrueLayer_Payment_Gateway extends WC_Payment_Gateway {
 	 * @var string
 	 */
 	public $testmode;
+
+	/**
+	 * The plugin logging setting value.
+	 *
+	 * @var string
+	 */
+	public $logging;
 
 	/**
 	 * Class constructor.

--- a/classes/requests/post/class-truelayer-request-create-payment.php
+++ b/classes/requests/post/class-truelayer-request-create-payment.php
@@ -86,6 +86,11 @@ class TrueLayer_Request_Create_Payment extends TrueLayer_Request_Post {
 			$body['payment_method']['provider_selection']['filter']['customer_segments'] = $customer_segment;
 		}
 
+		$release_channel = $this->get_release_channel();
+		if ( ! empty( $release_channel ) ) {
+			$body['payment_method']['provider_selection']['filter']['release_channel'] = $release_channel;
+		}
+
 		return $body;
 	}
 
@@ -143,5 +148,15 @@ class TrueLayer_Request_Create_Payment extends TrueLayer_Request_Post {
 	private function get_banking_providers() {
 		$banking_providers = empty( $this->settings['truelayer_banking_providers'] ) ? array() : $this->settings['truelayer_banking_providers'];
 		return array_map( 'strtolower', $banking_providers );
+	}
+
+	/**
+	 * Returns the release channel
+	 *
+	 * @return array
+	 */
+	private function get_release_channel() {
+		$release_channel = empty( $this->settings['truelayer_release_channel'] ) ? array() : $this->settings['truelayer_release_channel'];
+		return $release_channel;
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,8 @@
         "platform": {
             "php": "7.4"
         }
+    },
+    "require-dev": {
+        "php-stubs/woocommerce-stubs": "^8.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e1252d8b7ab490329509e8e844d157f",
+    "content-hash": "e010ccaf3d551c29c897b5377b4c357c",
     "packages": [
         {
             "name": "brick/math",
@@ -1276,7 +1276,96 @@
             "time": "2021-01-21T19:18:03+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "php-stubs/woocommerce-stubs",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/woocommerce-stubs.git",
+                "reference": "f5a8621ca0a28c93b37b827ef92e7b49ad3d1923"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/f5a8621ca0a28c93b37b827ef92e7b49ad3d1923",
+                "reference": "f5a8621ca0a28c93b37b827ef92e7b49ad3d1923",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^5.3 || ^6.0"
+            },
+            "require-dev": {
+                "php": "~7.1 || ~8.0",
+                "php-stubs/generator": "^0.8.0"
+            },
+            "suggest": {
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WooCommerce function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/woocommerce-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "woocommerce",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v8.1.0"
+            },
+            "time": "2023-09-12T20:25:04+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c",
+                "reference": "adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13",
+                "php": "^7.4 || ~8.0.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^5.3",
+                "phpstan/phpstan": "^1.10.12",
+                "phpunit/phpunit": "^9.5"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.3.0"
+            },
+            "time": "2023-08-10T16:34:11+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],


### PR DESCRIPTION
Adds a setting to allow the merchant to add a custom release_channel to the payment request which is added to payment_method.provider_selection.filter.release_channel